### PR TITLE
use official postgres v16 image to support raspberry pi architecture

### DIFF
--- a/watcher/docker-compose.yaml
+++ b/watcher/docker-compose.yaml
@@ -2,11 +2,11 @@ version: '3.8'
 
 services:
   db:
-    image: rapidfort/postgresql:16.0.0
+    image: postgres:16.1
     env_file:
       - .env
     volumes:
-      - postgres-data:/bitnami/postgresql
+      - postgres-data:/var/lib/postgresql/data
     networks:
       - rosen_network
     restart: always


### PR DESCRIPTION
The bitnami image does not support linux/arm64/v8 architecture used by raspberry pi's. Since a lot of user intend to run the watcher service on raspberry it should be supported.