### PR TITLE
Changed localhost to 0.0.0.0

### DIFF
--- a/watcher/docker-compose.yaml
+++ b/watcher/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       - rosen_network
     restart: always
     ports:
-      - 127.0.0.1:${WATCHER_PORT:-3030}:80
+      - 0.0.0.0:${WATCHER_PORT:-3030}:80
     volumes:
       - nginx-logs:/var/log/nginx
     depends_on:


### PR DESCRIPTION
Running a Watcher in a container.  Ran into issue that 127.0.0.1 was not reachable from network.  Is there a reason for it to be localhost only?  If not, 0.0.0.0 would give fewer headaches to new Watchers.