### PR TITLE
clarifications on env variable setup updates & warning verboseness for security

### DIFF
--- a/docs/guard/env-references.md
+++ b/docs/guard/env-references.md
@@ -1,6 +1,6 @@
 ## Environment Variable References
 Note: 
-- For the environmental variable file, no quotes are needed around the the strings. 
+- For the environmental variable file, no quotes are needed around the strings. 
 - Delete all comments after copying and pasting in.
 - Delete all whitespaces after the last word of the line item entry.
 

--- a/docs/guard/env-references.md
+++ b/docs/guard/env-references.md
@@ -20,7 +20,7 @@ POSTGRES_PORT=5432 # 5432 is set as default, you can change it.
 ```
 API_KEY_HASH= # blake2b hash of api_key, e.g. API_KEY_HASH=myHashHere
 
-MNEMONIC= # ergo mnemonic phrases, e.g. MNEMONIC= word1 word2 word3 ... wordn
+MNEMONIC= # ergo mnemonic phrases, e.g. MNEMONIC=word1 word2 word3 ... wordn
 
 TSS_SECRET= # the secret used to encrypt messages to start the signing process
 

--- a/docs/guard/env-references.md
+++ b/docs/guard/env-references.md
@@ -20,7 +20,7 @@ POSTGRES_PORT=5432 # 5432 is set as default, you can change it.
 ```
 API_KEY_HASH= # blake2b hash of api_key, e.g. API_KEY_HASH=myHashHere
 
-MNEMONIC= # watcher mnemonic phrases, e.g. MNEMONIC= word1 word2 word3 ... wordn
+MNEMONIC= # ergo mnemonic phrases, e.g. MNEMONIC= word1 word2 word3 ... wordn
 
 TSS_SECRET= # the secret used to encrypt messages to start the signing process
 

--- a/docs/guard/env-references.md
+++ b/docs/guard/env-references.md
@@ -1,4 +1,8 @@
 ## Environment Variable References
+Note: 
+- For the environmental variable file, no quotes are needed around the the strings. 
+- Delete all comments after copying and pasting in.
+- Delete all whitespaces after the last word of the line item entry.
 
 # Required Environments
 ```
@@ -14,9 +18,9 @@ POSTGRES_PORT=5432 # 5432 is set as default, you can change it.
 
 # Optional Environments
 ```
-API_KEY_HASH= # blake2b hash of api_key
+API_KEY_HASH= # blake2b hash of api_key, e.g. API_KEY_HASH=myHashHere
 
-MNEMONIC= # ergo mnemonic phrases
+MNEMONIC= # watcher mnemonic phrases, e.g. MNEMONIC= word1 word2 word3 ... wordn
 
 TSS_SECRET= # the secret used to encrypt messages to start the signing process
 

--- a/docs/guard/setup.md
+++ b/docs/guard/setup.md
@@ -44,7 +44,7 @@ Use [rosen command line](https://github.com/rosen-bridge/utils/tree/dev/packages
 #### Update Configuration File
 After obtaining the hash, input it into your config file. For example, the Blake2b hash of `hello` is `324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf`.
 
-> **NOTE**: When using docker there is an `API_KEY_HASH` environment variable available for `apiKeyHash` that you can set instead of in the local configuration.
+> **⚠️ NOTE**: When using docker there is an `API_KEY_HASH` environment variable available for `apiKeyHash` that you can set instead of in the local configuration. See your `.env` file. We recommend utilizing environment variables over direct configuration file settings for **security** purpose to not accidently share your api key while troubleshooting etc. After updating, you can delete `apiKeyHash` from /config/local.yaml.
 
 ## DATABASE
 Specify your database connection and credentials.
@@ -245,7 +245,7 @@ guard:
   mnemonic: 'YOUR_MNEMONIC'
 ```
 
-> **NOTE**: Instead of setting `mnemonic` in the local configuration file, consider using the `MNEMONIC` environment variable for ease of management. We recommend utilizing environment variables over direct configuration file settings.
+> **⚠️ NOTE**: Instead of setting `mnemonic` in the local configuration file, consider using the `MNEMONIC` environment variable for ease of management. We recommend utilizing environment variables over direct configuration file settings for **security** purpose to not accidently share your seed phrase while troubleshooting etc. See your `.env` file. Once updated, in /config/local.yaml delete your mnemonic phrase and put in a comment like so "mnemonic: #see local config env file"
 
 ## Logs
 

--- a/docs/watcher/deploy-docker.md
+++ b/docs/watcher/deploy-docker.md
@@ -17,6 +17,8 @@ Create your environment file `.env` based on `env.template` file in the `watcher
 cp env.template .env
 ```
 
+To view hidden .env later, use `ls -a`.
+
 ## Environment Variable Configs
 You can configure some Environment Variables when deploying with docker, you can find all of them [here](./env-references.md).
 
@@ -94,7 +96,9 @@ Use [rosen command line](https://github.com/rosen-bridge/utils/tree/dev/packages
 #### Update Configuration File
 After obtaining the hash, input it into your config file. For example, the Blake2b hash of `hello` is `324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf`.
 
-> **NOTE**: When using docker there is an `API_KEY_HASH` environment variable available for `apiKeyHash` that you can set instead of in the local configuration.
+> **⚠️ NOTE**: When using docker there is an `API_KEY_HASH` environment variable available for `apiKeyHash` that you can set instead of in the local configuration. See your `.env` file. We recommend utilizing environment variables over direct configuration file settings for **security** purpose to not accidently share your api key while troubleshooting etc. After updating, you can delete `apiKeyHash` from /config/local.yaml.
+
+
 
 ### Ergo Config (Essential for all watchers)
 
@@ -108,7 +112,7 @@ mnemonic: <your wallet mnemonic>
 
 > Note: Utilizing this mnemonic in a standard multi-address wallet will lead to watcher misbehavior.
 
-> **NOTE**: Instead of setting `mnemonic` in the local configuration file, consider using the `MNEMONIC` environment variable for ease of management. We recommend utilizing environment variables over direct configuration file settings.
+> **⚠️ NOTE**: Instead of setting `mnemonic` in the local configuration file, consider using the `MNEMONIC` environment variable for ease of management. We recommend utilizing environment variables over direct configuration file settings for **security** purpose to not accidently share your seed phrase while troubleshooting etc. See your `.env` file. Once updated, in /config/local.yaml delete your mnemonic phrase and put in a comment like so "mnemonic: #see local config env file"
 
 1. Select your primary data source for the Ergo network; block and box information are retrieved from this source. You can use either `explorer` or `node` as the primary source:
 

--- a/docs/watcher/env-references.md
+++ b/docs/watcher/env-references.md
@@ -20,7 +20,7 @@ POSTGRES_PORT=5432 # 5432 is set as default, you can change it.
 ```
 API_KEY_HASH= # blake2b hash of api_key, e.g. API_KEY_HASH=myHashHere
 
-MNEMONIC= # watcher mnemonic phrases, e.g. MNEMONIC= word1 word2 word3 ... wordn
+MNEMONIC= # watcher mnemonic phrases, e.g. MNEMONIC=word1 word2 word3 ... wordn
 
 KOIOS_AUTH_TOKEN=
 

--- a/docs/watcher/env-references.md
+++ b/docs/watcher/env-references.md
@@ -1,5 +1,8 @@
 ## Environment Variable References
-
+Note: 
+- For the environmental variable file, no quotes are needed around the the strings. 
+- Delete all comments after copying and pasting in.
+- Delete all whitespaces after the last word of the line item entry.
 
 # Required Environments
 ```
@@ -15,9 +18,9 @@ POSTGRES_PORT=5432 # 5432 is set as default, you can change it.
 
 # Optional Environments
 ```
-API_KEY_HASH= # blake2b hash of api_key
+API_KEY_HASH= # blake2b hash of api_key, e.g. API_KEY_HASH=myHashHere
 
-MNEMONIC= # watcher mnemonic phrases
+MNEMONIC= # watcher mnemonic phrases, e.g. MNEMONIC= word1 word2 word3 ... wordn
 
 KOIOS_AUTH_TOKEN=
 


### PR DESCRIPTION
Added to watcher and guard operations based on my own troubleshooting updating for v.1.1.2:

- Extra verbiage on the local config vs environmental config setup process
   - warning emoji up front, 
   - recommended approach for security purposes to not share seed phrase (extra explicit & verbose since this could easily be missed or under emphasized),
   - clean-up instructions
  
- env-references.md, added to comment examples for API_KEY_HASH and MNEOMIC, added notes to the top based on troubleshooting
  - no quotes, 
  - no whitespace at the end, 
  - delete comments when done
