### PR TITLE
Remove deprecated version field from docker-compose.yaml

### DIFF
--- a/watcher/docker-compose.yaml
+++ b/watcher/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:17.0


### PR DESCRIPTION
Docker Compose v2 deprecated the top-level `version` field. It is now
ignored and produces this warning on every `docker compose up`:

    the attribute `version` is obsolete, it will be ignored, please
    remove it to avoid potential confusion

Removing the field silences the warning with no functional change.